### PR TITLE
Fix "fs.rmdir" deprecation notice

### DIFF
--- a/src/rmOutputDir.ts
+++ b/src/rmOutputDir.ts
@@ -2,7 +2,7 @@ import FS from 'fs';
 
 export async function rmOutputDir() {
   try {
-    await FS.promises.rmdir('./output', {recursive: true});
+    await FS.promises.rm('./output', {recursive: true});
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
Fix #31

Whenever we run the app, we get this error message.

```
(node:57555) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```